### PR TITLE
Documentation updates

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,8 +32,7 @@ import os
 extensions = [
    'sphinx.ext.autodoc',
    'sphinx.ext.todo',
-   'sphinx.ext.pngmath',
-   'sphinx.ext.mathjax',
+   'sphinx.ext.imgmath'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -23,7 +23,7 @@ PhyloToAST_ is avaiable on the Python Package Index (PyPI), and can be easily in
         $ pip install phylotoast
 
 .. _PhyloToAST: https://pypi.python.org/pypi/phylotoast
-   
+
 Using PhyloToAST
 ==================
 .. toctree::
@@ -38,21 +38,19 @@ Using PhyloToAST
 Citing PhyloToAST
 ==================
 
-Dabdoub, S.M. et al., *PhyloToAST: Bioinformatics tools for
-species-level analysis and visualization of complex microbial communities*.
-2016. (Manuscript in revision).
+Dabdoub, S. M. et al. PhyloToAST: Bioinformatics tools for species-level analysis and visualization of complex microbial datasets. Sci. Rep. 6, 29123, 2016; doi: `10.1038/srep29123 <http://dx.doi.org/10.1038/srep29123>`_
 
 
 Publications using PhyloToAST
 =============================
 Tsigarida and Dabdoub et al., *The Influence of Smoking on the Peri-Implant
-Microbiome*. Journal of Dental Research, 2015; `doi: 10.1177/0022034515590581`_
+Microbiome*. Journal of Dental Research, 2015; doi: `10.1177/0022034515590581 <http://jdr.sagepub.com/content/94/9/1202.full>`_
 
 Mason et al., *The subgingival microbiome of clinically healthy current
-and never smokers*. The ISME Journal, 2014; `doi:10.1038/ismej.2014.114`_
+and never smokers*. The ISME Journal, 2014; doi: `10.1038/ismej.2014.114 <http://www.nature.com/ismej/journal/v9/n1/full/ismej2014114a.html>`_
 
 Dabdoub et al., *Patient-specific Analysis of Periodontal and Peri-implant Microbiomes*.
-Journal of Dental Research, 2013; `doi: 10.1177/0022034513504950`_
+Journal of Dental Research, 2013; doi: `10.1177/0022034513504950 <http://jdr.sagepub.com/content/92/12_suppl/168S.full>`_
 
 
 References

--- a/docs/scripts/LDA.txt
+++ b/docs/scripts/LDA.txt
@@ -2,20 +2,22 @@
 LDA.py
 ========
 
-Create an LDA plot from sample-grouped OTU data. It is necessary to remove the
-header cell '#OTU ID' before running this program.
+Create an LDA plot from sample-grouped OTU data. It is necessary to remove the header cell '#OTU ID' before running this program.
 
 .. code-block:: bash
 
-        usage: LDA.py [-h] -i BIOM_TSV -m MAP_FP -g GROUP_BY [GROUP_BY ...] -c COLOR_BY [--dpi DPI] [--save_lda_input SAVE_LDA_INPUT] [--plot_title PLOT_TITLE] [-o OUT_FP]
+        usage: LDA.py [-h] -i {biom,unifrac_dm} -bf BIOM_FILE -m MAP_FP [-uf UNIFRAC_FILE] -g GROUP_BY -c COLOR_BY [--bubble BUBBLE] [--save_lda_input SAVE_LDA_INPUT] [--plot_title PLOT_TITLE] [-o OUT_FP] [-od OUTPUT_DIR] [--scale_by SCALE_BY] [-s SAVE_AS] [--ggplot2_style]
 
 Required arguments
 ^^^^^^^^^^^^^^^^^^^^
 
-.. cmdoption:: -i BIOM_TSV, --biom_tsv BIOM_TSV
+.. cmdoption:: -i {biom,unifrac_dm}, --input_data_type {biom,unifrac_dm}
 
-    Sample-OTU abundance table in TSV format with the arcsin sqrt transform
-    already applied.
+    Specify if the input file is biom file format OTU table or unifrac distance matrix. If biom file is provided, the arc-sine transformed relative abundances will be used as input whereas, if unifrac distance matrix. is given, unifrac distances will be used as input to LDA.
+
+.. cmdoption:: -bf BIOM_FILE, --biom_file BIOM_FILE
+
+    Input biom file format.
 
 .. cmdoption:: -m MAP_FP, --map_fp MAP_FP
 
@@ -24,29 +26,25 @@ Required arguments
 Optional arguments
 ^^^^^^^^^^^^^^^^^^
 
+..cmdoption:: -uf UNIFRAC_FILE, --unifrac_file UNIFRAC_FILE
+
+    Input unifrac distance matrix file. This is the output from QIIME's beta_diversity.py script.
+
 .. cmdoption:: -g GROUP_BY [GROUP_BY ...], --group_by GROUP_BY [GROUP_BY ...]
 
-    Any mapping categories, such as treatment type, that will be used to group
-    the data in the output iTol table. For example, one category with three
-    types will result in three data columns in the final output. Two categories
-    with three types each will result in six data columns. Default is no
-    categories and all the data will be treated as a single group.
+    A column name in the mapping file containing categorical values that will be used to identify groups. Each sample ID must have a group entry. Default is no categories and all the data will be treated as a single group.
 
 .. cmdoption:: -c COLOR_BY, --color_by COLOR_BY
 
-    A column name in the mapping file containing hexadecimal (#FF0000) color
-    values that will be used to color the groups. Each sample ID must have a
-    color entry.
+    A column name in the mapping file containing hexadecimal (#FF0000) color values that will be used to color the groups. Each sample ID must have a color entry.
 
-.. cmdoption:: --dpi DPI
+.. cmdoption:: --bubble BUBBLE
 
-    Set plot quality in Dots Per Inch (DPI). Larger DPI will result in larger
-    file size.
+    If set, provide a file with 1 OTU name per line for bubble plotting. OTU name must be condensed to genus-species identifier. Default parameter value will not plot bubble plots.
 
 .. cmdoption:: --save_lda_input SAVE_LDA_INPUT
 
-    Save a CSV-format file of the transposed LDA-input table to the file
-    specifed by this option.
+    Save a CSV-format file of the transposed LDA-input table to the file specifed by this option.
 
 .. cmdoption:: --plot_title PLOT_TITLE
 
@@ -54,9 +52,19 @@ Optional arguments
 
 .. cmdoption:: -o OUT_FP, --out_fp OUT_FP
 
-    The path and file name to save the plot under. If specified, the figure
-    will be saved directly instead of opening a window in which the plot can be
-    viewed before saving.
+    The path and file name to save the plot under. If specified, the figure will be saved directly instead of opening a window in which the plot can be viewed before saving.
+
+.. cmdoption:: --scale_by SCALE_BY
+
+    Species relative abundance is multiplied by this factor in order to make appropriate visible bubbles in the output plots. Default is 1000.
+
+.. cmdoption:: -s SAVE_AS, --save_as SAVE_AS
+
+    The type of image file for LDA plots. By default, files will be saved in SVG format.
+
+.. cmdoption:: --ggplot2_style
+
+    Apply ggplot2 styling to the figure.
 
 .. cmdoption:: -h, --help
 

--- a/docs/scripts/PCoA_bubble.txt
+++ b/docs/scripts/PCoA_bubble.txt
@@ -1,10 +1,7 @@
 PCoA_bubble.py
 ===============
 
-Create a series of Principle Coordinate plots for each OTU in an input list
-where the plot points are varied in size by the relative abundance of the OTU
-(relative to either Sample or the total contribution of the OTU to the data
-set.
+Create a series of Principle Coordinate plots for each OTU in an input list where the plot points are varied in size by the relative abundance of the OTU (relative to either Sample or the total contribution of the OTU to the data set.
 
 .. code-block:: bash
 
@@ -17,28 +14,25 @@ Required Arguments
 
     The biom-format file with OTU-Sample abundance data.
 
-.. cmdoption:: -u UNIFRAC, --unifrac UNIFRAC
-
-    Principle coordinates analysis file. Eg. unweighted_unifrac_pc.txt
-
-.. cmdoption:: -d NAMES_COLORS_IDS_FN, --names_colors_ids_fn NAMES_COLORS_IDS_FN
-
-    The name of an input data file containing three items:
-    Line 1: a tab-separated list of display names for the different types in
-    the specified mapping category (--mapping_category), Line 2: a matching
-    tab-separated list of hexadecimal colors for each of the category types,
-    Lines 3-end: a tab-separated pair specifying OTU ID and OTU Name. Each
-    entry will get a separate PCoA plot under a file with the name of the OTU.
-
 .. cmdoption:: -m MAPPING, --mapping MAPPING
 
     The mapping file specifying group information for each sample.
 
-.. cmdoption:: -c MAP_CATEGORY, --map_category MAP_CATEGORY
+.. cmdoption:: -u UNIFRAC, --unifrac UNIFRAC
 
-    Any mapping category, such as treatment type, that will be used to group
-    the data in the output plots. For example, one category with three types
-    will result in three different point sets in the final output.
+    Principle coordinates analysis file. Eg. unweighted_unifrac_pc.txt
+
+.. cmdoption:: -b GROUP_BY, --group_by GROUP_BY
+
+    Column name in mapping file specifying group information.
+
+.. cmdoption::  -c COLORS, --colors COLORS
+
+    A column name in the mapping file containing hexadecimal (#FF0000) color values that will be used to color the groups. Each sample ID must have a color entry.
+
+.. cmdoption:: -d NAMES_COLORS_IDS_FN, --names_colors_ids_fn NAMES_COLORS_IDS_FN
+
+    File containing one OTU name per line for plotting.
 
 Optional Arguments
 ------------------
@@ -47,14 +41,21 @@ Optional Arguments
 
     The directory to output the PCoA plots to.
 
-.. cmdoption:: --scaling_factor SCALING_FACTOR
+.. cmdoption:: -s SAVE_AS, --save_as SAVE_AS
 
-    Species relative abundance is multiplied by this factor in order to make
-    appropriate visible bubbles in the output plots. Default is 10000.
+    The type of image file for PCoA plots. By default, files will be saved in SVG format.
+
+.. cmdoption::  --scale_by SCALE_BY
+
+    Species relative abundance is multiplied by this factor in order to make appropriate visible bubbles in the output plots. Default is 10000.
+
+.. cmdoption:: --ggplot2_style
+
+    Apply ggplot2 styling to the figure.
 
 .. cmdoption:: -v, --verbose
 
-    Displays species name as each is being plotted and stored to disk.
+    Displays species name as each is being plotted and saved.
 
 .. cmdoption:: -h, --help
 

--- a/docs/scripts/available_scripts.txt
+++ b/docs/scripts/available_scripts.txt
@@ -10,18 +10,22 @@ All available PhyloToAST scripts.
    biom_relative_abundance
    condense_workflow
    diversity
-   filter_keep_otus_by_sample.txt
+   extract_uniques
+   filter_keep_otus_by_sample
    filter_rep_set
+   iTol
+   LDA
    merge_otu_results
    multi_parallel_pick_otus
    multi_qsub
    otu_condense
    otu_to_tax_name
+   PCoA
+   PCoA_bubble
    pick_otus_condense
    primer_average
    prune_otus
    restrict_repset
    split_sequence_data
    transpose_biom
-
 

--- a/docs/scripts/data_handling.txt
+++ b/docs/scripts/data_handling.txt
@@ -9,10 +9,12 @@ PhyloToAST scripts for data analysis and manipulation.
    barcode_filter
    biom_relative_abundance
    condense_workflow
+   extract_uniques
    filter_rep_set
    merge_otu_results
    multi_parallel_pick_otus
    multi_qsub
+   network_plots_gephi
    otu_condense
    otu_to_tax_name
    pick_otus_condense

--- a/docs/scripts/extract_uniques.txt
+++ b/docs/scripts/extract_uniques.txt
@@ -1,0 +1,38 @@
+extract_uniques.py
+==================
+
+Parse a BIOM format file and obtain a list of unique OTUIDs found in each category in mapping file.
+
+    .. code-block:: bash
+
+        usage: extract_uniques.py [-h] [-p PREFIX] input_biom_fp output_dir mapping_file category_column
+
+Required arguments
+^^^^^^^^^^^^^^^^^^
+
+.. cmdoption:: input_biom_fp
+
+    BIOM format file path.
+
+.. cmdoption:: output_dir
+
+    Path to save category unique OTUIDs.
+
+.. cmdoption:: mapping_file
+
+    Mapping file with category information.
+
+.. cmdoption:: category_column
+
+    Column in mapping file specifying the category/condition of all samples.
+
+Optional arguments
+^^^^^^^^^^^^^^^^^^
+
+.. cmdoption:: -p PREFIX, --prefix PREFIX
+
+    Provide specific text to prepend the output file names. By default, the 'unique' will be added in front of output filenames.
+
+.. cmdoption:: -h, --help
+
+    Show the help message and exit

--- a/docs/scripts/subsetting.txt
+++ b/docs/scripts/subsetting.txt
@@ -1,9 +1,0 @@
-============
-Subsetting
-============
-PhyloToAST script for enabling user to work with subset of the overall data.
-
-.. toctree::
-   :maxdepth: 1
-
-   filter_keep_otus_by_sample.txt


### PR DESCRIPTION
- Added documentation page for [extract_uniques.py](https://github.com/smdabdoub/phylotoast/blob/master/bin/extract_uniques.py) script.
- Updated PhyloToAST front-page documentation with updated citation information and added links to publication DOIs.
- Updated [LDA.py](https://github.com/smdabdoub/phylotoast/blob/master/bin/LDA.py) documentation for modified usage and parameters.
- Updated [PCoA_bubble.py](https://github.com/smdabdoub/phylotoast/blob/master/bin/PCoA_bubble.py) documentation for modified usage and improved parameter list.
- Updated available PhyloToAST script list.
- Updated PhyloToAST data handling script list.
- Replaced deprecated math extension with new one in the documentation configuration file.
- Removed subsetting.txt. It is not used anywhere in documentation toc tree.