### PR TITLE
Updated documentation for PCoA_bubble script and fixed a bug in extract_shared_or_unique_otuids.py script

### DIFF
--- a/bin/extract_shared_or_unique_otuids.py
+++ b/bin/extract_shared_or_unique_otuids.py
@@ -94,16 +94,19 @@ def shared_otuids(groups):
     :return type: dict
     :return: Dict keyed on group combination and their shared OTUIDs as values.
     """
+    for g in sorted(groups):
+        print "# of OTUs in {}: {}".format(g, len(groups[g].results["otuids"]))
     number_of_categories = len(groups)
     shared = defaultdict()
     for i in range(2, number_of_categories+1):
         for j in combinations(sorted(groups), i):
             combo_name = " & ".join(list(j))
-            # initialize combo values with set elements
-            shared[combo_name] = groups[j[0]].results["otuids"]
-            # iterate through all groups and keep updating combo OTUIDs with intersection_update
-            for grp in j[1:]:
-                shared[combo_name].intersection_update(groups[grp].results["otuids"])
+            for grp in j:
+                # initialize combo values
+                shared[combo_name] = groups[j[0]].results["otuids"].copy()
+                # iterate through all groups and keep updating combo OTUIDs with intersection_update
+                for grp in j[1:]:
+                    shared[combo_name].intersection_update(groups[grp].results["otuids"])
     return shared
 
 

--- a/docs/scripts/PCoA_bubble.txt
+++ b/docs/scripts/PCoA_bubble.txt
@@ -1,11 +1,11 @@
 PCoA_bubble.py
 ===============
 
-Create a series of Principle Coordinate plots for each OTU in an input list where the plot points are varied in size by the relative abundance of the OTU (relative to either Sample or the total contribution of the OTU to the data set.
+Create a series of Principal Coordinate plots for each OTU in an input list where the plot points are varied in size by the relative abundance of the OTU (relative to either Sample or the total contribution of the OTU to the data set.
 
 .. code-block:: bash
 
-    usage: PCoA_bubble.py [-h] -i OTU_TABLE -u UNIFRAC -d NAMES_COLORS_IDS_FN -m MAPPING -c MAP_CATEGORY [-o OUTPUT_DIR] [--scaling_factor SCALING_FACTOR] [-v]
+    usage: PCoA_bubble.py [-h] -i OTU_TABLE -m MAPPING -pc PCOA_FP -b GROUP_BY [-c COLORS] -ids OTU_IDS_FP [-o OUTPUT_DIR] [-s SAVE_AS] [--scale_by SCALE_BY] [--ggplot2_style] [-v]
 
 Required Arguments
 -------------------
@@ -18,9 +18,9 @@ Required Arguments
 
     The mapping file specifying group information for each sample.
 
-.. cmdoption:: -u UNIFRAC, --unifrac UNIFRAC
+.. cmdoption:: -pc PCOA_FP, --pcoa_fp PCOA_FP
 
-    Principle coordinates analysis file. Eg. unweighted_unifrac_pc.txt
+    Principal Coordinates Analysis file. Eg. unweighted_unifrac_pc.txt, or any other output from principal_coordinates.py.
 
 .. cmdoption:: -b GROUP_BY, --group_by GROUP_BY
 
@@ -30,9 +30,9 @@ Required Arguments
 
     A column name in the mapping file containing hexadecimal (#FF0000) color values that will be used to color the groups. Each sample ID must have a color entry.
 
-.. cmdoption:: -d NAMES_COLORS_IDS_FN, --names_colors_ids_fn NAMES_COLORS_IDS_FN
+.. cmdoption:: -ids OTU_IDS_FP, --otu_ids_fp OTU_IDS_FP
 
-    File containing one OTU name per line for plotting.
+    Path to a file containing one OTU ID per line. One plot will be created for each OTU.
 
 Optional Arguments
 ------------------


### PR DESCRIPTION
- For changes made in _PCoA_bubble.py_

- Updated _extract_shared_or_unique_otuids.py_
  - Corrected the method to calculate shared OTUs.
    -  Earlier, the input set to `shared_otuids()` function was getting updated, which created in accurate results for multiple category combinations.
    - Fixed the problem by initializing new set with a copy of the input set rather than initializing it with the input set itself.
  - In addition, the script prints out number of OTUs in each category, while getting shared OTUs among all group combinations.