### PR TITLE
Updates to extract_shared_or_unique_otuids.py and filter_biom.py and test scripts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,16 @@
 # Python files
 *.py[cod]
 
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
 # Sequence-related
 *.fasta
 *.biom

--- a/phylotoast/biom_calc.py
+++ b/phylotoast/biom_calc.py
@@ -1,11 +1,8 @@
 """
-Created on Feb 19, 2013
-
-:author: Shareef Dabdoub
-
-This module provides methods for calculating various metrics with regards to
-each OTU in an input OTU abundance table. This is currently used by iTol.py
-to offload the different methods.
+:Date: Created on Feb 19, 2013
+:Author: Shareef Dabdoub
+:Abstract: This module provides methods for calculating various metrics with regards to
+           each OTU in an input OTU abundance table.
 """
 import math
 from collections import defaultdict
@@ -22,9 +19,9 @@ def relative_abundance(biomf, sampleIDs=None):
     :param sampleIDs: A list of sample id's from BIOM format OTU table.
 
     :rtype: dict
-    :return: Returns a keyed on SampleIDs, and the values are dictionaries
-             keyed on OTUID's and their values represent the relative
-             abundance of that OTUID in that SampleID.
+    :return: Returns a keyed on SampleIDs, and the values are dictionaries keyed on
+             OTUID's and their values represent the relative abundance of that OTUID in
+             that SampleID.
     """
     if sampleIDs is None:
         sampleIDs = biomf.ids()
@@ -34,9 +31,9 @@ def relative_abundance(biomf, sampleIDs=None):
                 assert sid in biomf.ids()
         except AssertionError:
             raise ValueError(
-                "\nError while calculating relative abundances: The sampleIDs "
-                "provided do not match the sampleIDs in biom file. Please "
-                "double check the sampleIDs provided.\n")
+                "\nError while calculating relative abundances: The sampleIDs provided do"
+                " not match the sampleIDs in biom file. Please double check the sampleIDs"
+                " provided.\n")
     otuIDs = biomf.ids(axis="observation")
     norm_biomf = biomf.norm(inplace=False)
 
@@ -49,32 +46,30 @@ def mean_otu_pct_abundance(ra, otuIDs):
     Calculate the mean OTU abundance percentage.
 
     :type ra: Dict
-    :param ra: 'ra' refers to a dictionary keyed on SampleIDs, and the values
-                are dictionaries keyed on OTUID's and their values represent
-                the relative abundance of that OTUID in that SampleID. 'ra' is
-                the output of relative_abundance() function.
+    :param ra: 'ra' refers to a dictionary keyed on SampleIDs, and the values are
+               dictionaries keyed on OTUID's and their values represent the relative
+               abundance of that OTUID in that SampleID. 'ra' is the output of
+               relative_abundance() function.
 
     :type otuIDs: List
-    :param otuIDs: A list of OTUID's for which the percentage abundance needs
-                   to be measured.
+    :param otuIDs: A list of OTUID's for which the percentage abundance needs to be
+                   measured.
 
     :rtype: dict
-    :return: A dictionary of OTUID and their percent relative
-                      abundance as key/value pair.
+    :return: A dictionary of OTUID and their percent relative abundance as key/value pair.
     """
     sids = ra.keys()
     otumeans = defaultdict(int)
 
     for oid in otuIDs:
         otumeans[oid] = sum([ra[sid][oid] for sid in sids
-                            if oid in ra[sid]]) / len(sids) * 100
-
+                             if oid in ra[sid]]) / len(sids) * 100
     return otumeans
 
 
 def MRA(biomf, sampleIDs=None, transform=None):
     """
-    Calculate the mean relative abundance.
+    Calculate the mean relative abundance percentage.
 
     :type biomf: A BIOM file.
     :param biomf: OTU table format.
@@ -83,8 +78,8 @@ def MRA(biomf, sampleIDs=None, transform=None):
     :param sampleIDs: A list of sample id's from BIOM format OTU table.
 
     :rtype: dict
-    :return: A dictionary keyed on OTUID's and their mean relative abundance
-             for a given number of sampleIDs.
+    :return: A dictionary keyed on OTUID's and their mean relative abundance for a given
+             number of sampleIDs.
     """
     ra = relative_abundance(biomf, sampleIDs)
     if transform is not None:
@@ -101,17 +96,16 @@ def raw_abundance(biomf, sampleIDs=None, sample_abd=True):
     :param biomf: OTU table format.
 
     :type sampleIDs: List
-    :param sampleIDs: A list of column id's from BIOM format OTU table. By
-                      default, the list has been set to None.
+    :param sampleIDs: A list of column id's from BIOM format OTU table. By default, the
+                      list has been set to None.
 
     :type sample_abd: Boolean
-    :param sample_abd: A boolean operator to provide output for OTUID's or
-                       SampleID's. By default, the output will be provided
-                       for SampleID's.
+    :param sample_abd: A boolean operator to provide output for OTUID's or SampleID's. By
+                       default, the output will be provided for SampleID's.
 
     :rtype: dict
-    :return: Returns a dictionary keyed on either OTUID's or SampleIDs
-                     and their respective abundance as values.
+    :return: Returns a dictionary keyed on either OTUID's or SampleIDs and their
+             respective abundance as values.
     """
     results = defaultdict(int)
     if sampleIDs is None:
@@ -122,9 +116,9 @@ def raw_abundance(biomf, sampleIDs=None, sample_abd=True):
                 assert sid in biomf.ids()
         except AssertionError:
             raise ValueError(
-                "\nError while calculating raw total abundances: The "
-                "sampleIDs provided do not match the sampleIDs in biom file. "
-                "Please double check the sampleIDs provided.\n")
+                "\nError while calculating raw total abundances: The sampleIDs provided "
+                "do not match the sampleIDs in biom file. Please double check the "
+                "sampleIDs provided.\n")
     otuIDs = biomf.ids(axis="observation")
 
     for sampleID in sampleIDs:
@@ -137,24 +131,21 @@ def raw_abundance(biomf, sampleIDs=None, sample_abd=True):
     return results
 
 
-def transform_raw_abundance(biomf, fn=math.log10, sampleIDs=None,
-                            sample_abd=True):
+def transform_raw_abundance(biomf, fn=math.log10, sampleIDs=None, sample_abd=True):
     """
-    Function to transform the total abundance calculation for each sample ID
-    to another format based on user given transformation function.
+    Function to transform the total abundance calculation for each sample ID to another
+    format based on user given transformation function.
 
     :type biomf: A BIOM file.
     :param biomf: OTU table format.
 
-    :param fn: Mathematical function which is used to transform smax to
-               another format. By default, the function has been given as
-               base 10 logarithm.
+    :param fn: Mathematical function which is used to transform smax to another format.
+               By default, the function has been given as base 10 logarithm.
 
     :rtype: dict
-    :return: Returns a dictionary similar to output of raw_abundance function
-             but with the abundance values modified by the mathematical
-             operation. By default, the operation performed on the abundances
-             is base 10 logarithm.
+    :return: Returns a dictionary similar to output of raw_abundance function but with
+             the abundance values modified by the mathematical operation. By default, the
+             operation performed on the abundances is base 10 logarithm.
     """
     totals = raw_abundance(biomf, sampleIDs, sample_abd)
     return {sid: fn(abd) for sid, abd in totals.items()}

--- a/phylotoast/biom_calc.py
+++ b/phylotoast/biom_calc.py
@@ -77,13 +77,17 @@ def MRA(biomf, sampleIDs=None, transform=None):
     :type sampleIDs: list
     :param sampleIDs: A list of sample id's from BIOM format OTU table.
 
+    :param transform: Mathematical function which is used to transform smax to another
+                      format. By default, the function has been set to None.
+
     :rtype: dict
     :return: A dictionary keyed on OTUID's and their mean relative abundance for a given
              number of sampleIDs.
     """
     ra = relative_abundance(biomf, sampleIDs)
     if transform is not None:
-        ra = transform(ra)
+        ra = {sample: {otuID: transform(abd) for otuID, abd in ra[sample].items()}
+              for sample in ra.keys()}
     otuIDs = biomf.ids(axis="observation")
     return mean_otu_pct_abundance(ra, otuIDs)
 

--- a/phylotoast/test/test_biom_calc.py
+++ b/phylotoast/test/test_biom_calc.py
@@ -108,6 +108,27 @@ class biom_calc_Test(unittest.TestCase):
                 msg="Mean relative OTU percent abundance (MRA) not calculated accurately."
             )
 
+        # Checking MRA calc with transformation
+        hand_calc1 = {"GG_OTU_1": 35.0842846, "GG_OTU_2": 37.00402086,
+                      "GG_OTU_3": 47.88666428, "GG_OTU_4": 44.93767908,
+                      "GG_OTU_5": 40.35653848}
+        self.result1 = bc.MRA(self.biomf, transform=math.sqrt)
+        for oid in hand_calc1.keys():
+            self.assertAlmostEqual(
+                hand_calc1[oid], self.result1[oid],
+                msg="MRA with transformation not calculated accurately."
+            )
+
+        self.result2 = bc.MRA(self.biomf, transform=math.sin)
+        hand_calc2 = {"GG_OTU_1": 14.40790049, "GG_OTU_2": 15.6228805,
+                      "GG_OTU_3": 25.97876225, "GG_OTU_4": 22.62048068,
+                      "GG_OTU_5": 19.88517791}
+        for oid in hand_calc2.keys():
+            self.assertAlmostEqual(
+                hand_calc2[oid], self.result2[oid],
+                msg="MRA with transformation not calculated accurately."
+            )
+
     def test_raw_abundance(self):
         """
         Testing raw_abundance() function of biom_calc.py.
@@ -138,6 +159,13 @@ class biom_calc_Test(unittest.TestCase):
                              msg="Abundances not calculated for SampleID's")
         self.assertDictEqual(self.result3, hand_calc3,
                              msg="Abundances not calculated for OTUID's")
+
+        # Test for passed sampleID validity
+        with self.assertRaisesRegexp(ValueError, "\nError while calculating raw total "
+                                     "abundances: The sampleIDs provided do not match "
+                                     "the sampleIDs in biom file. Please double check "
+                                     "the sampleIDs provided.\n"):
+            bc.raw_abundance(self.biomf, sampleIDs=["NS01", "NS02", "NS03"])
 
     def test_relative_abundance(self):
         """
@@ -186,6 +214,13 @@ class biom_calc_Test(unittest.TestCase):
                     hand_calc[sid][otuid], self.result[sid][otuid],
                     msg="Relative abundances not calculated accurately."
                 )
+
+        # Test for valid sample IDs passed into function
+        with self.assertRaisesRegexp(ValueError, "\nError while calculating relative "
+                                     "abundances: The sampleIDs provided do not match "
+                                     "the sampleIDs in biom file. Please double check "
+                                     "the sampleIDs provided.\n"):
+            bc.relative_abundance(self.biomf, sampleIDs=["NS01", "NS02", "NS03"])
 
     def test_transform_raw_abundance(self):
         """

--- a/phylotoast/test/test_biom_calc.py
+++ b/phylotoast/test/test_biom_calc.py
@@ -17,86 +17,102 @@ class biom_calc_Test(unittest.TestCase):
         """
         self.biomf = load_table("phylotoast/test/test.biom")
 
-    def test_relative_abundance(self):
-        """
-        Testing relative abundance() function of biom.calc.py.
+    def test_arcsine_sqrt_transform(self):
+            """
+            Testing arcsine_sqrt_transform() function of biom_calc.py.
 
-        :return: Returns OK, if testing goal is achieved, otherwise raises
-                error.
-        """
-        self.result = bc.relative_abundance(self.biomf)
+            :return: Returns OK if testing goal is achieved, otherwise raises
+                     error.
+            """
+            self.result1 = bc.relative_abundance(self.biomf)
+            self.result2 = bc.arcsine_sqrt_transform(self.result1)
 
-        # List containing manual calculations
-        hand_calc = [0.181818182, 0, 0.545454545, 0.272727273, 0]
+            # Obtaining results to compare.
+            hand_calc = {"S1": {"GG_OTU_1": 0.453961252, "GG_OTU_2": 0.281034902,
+                                "GG_OTU_3": 0.453961252, "GG_OTU_4": 0.629014802,
+                                "GG_OTU_5": 0.453961252},
+                         "S10": {"GG_OTU_1": 0.292842772, "GG_OTU_2": 0.361367124,
+                                 "GG_OTU_3": 0.420534335, "GG_OTU_4": 0.615479709,
+                                 "GG_OTU_5": 0.570510448},
+                         "S2": {"GG_OTU_1": 0.413273808, "GG_OTU_2": 0.532861869,
+                                "GG_OTU_3": 0.532861869, "GG_OTU_4": 0.532861869,
+                                "GG_OTU_5": 0.256813917},
+                         "S3": {"GG_OTU_1": 0.339836909, "GG_OTU_2": 0.490882678,
+                                "GG_OTU_3": 0, "GG_OTU_4": 0.555121168,
+                                "GG_OTU_5": 0.673351617},
+                         "S4": {"GG_OTU_1": 0.440510663, "GG_OTU_2": 0,
+                                "GG_OTU_3": 0.830915552, "GG_OTU_4": 0.549467245,
+                                "GG_OTU_5": 0},
+                         "S5": {"GG_OTU_1": 0.299334026, "GG_OTU_2": 0.53606149,
+                                "GG_OTU_3": 0.584373897, "GG_OTU_4": 0.485049787,
+                                "GG_OTU_5": 0.36950894},
+                         "S6": {"GG_OTU_1": 0.615479709, "GG_OTU_2": 0.395099667,
+                                "GG_OTU_3": 0.575591472, "GG_OTU_4": 0.444859969,
+                                "GG_OTU_5": 0.1936583},
+                         "S7": {"GG_OTU_1": 0.270549763, "GG_OTU_2": 0.436286927,
+                                "GG_OTU_3": 0.387596687, "GG_OTU_4": 0.563942641,
+                                "GG_OTU_5": 0.602794553},
+                         "S8": {"GG_OTU_1": 0.501093013, "GG_OTU_2": 0.453961252,
+                                "GG_OTU_3": 0.588002604, "GG_OTU_4": 0.346579954,
+                                "GG_OTU_5": 0.403057074},
+                         "S9": {"GG_OTU_1": 0, "GG_OTU_2": 0.339836909,
+                                "GG_OTU_3": 0.729727656, "GG_OTU_4": 0,
+                                "GG_OTU_5": 0.729727656}}
 
-        # List containing the calculated relative abundance values
-        func_calc = self.result["S4"].values()
-
-        # Testing the validity of relative_abundance() function.
-        for hand, res in zip(hand_calc, func_calc):
-            self.assertAlmostEqual(
-                hand, res,
-                msg="Relative abundances not calculated accurately."
-                )
+            # Testing validity of the transforms.
+            for sid in sorted(hand_calc.keys()):
+                for otuid in sorted(hand_calc[sid].keys()):
+                    self.assertAlmostEqual(
+                        hand_calc[sid][otuid], self.result2[sid][otuid],
+                        msg="Arcsine squareroot transformation was not accurate."
+                    )
 
     def test_mean_otu_pct_abundance(self):
         """
         Testing mean_otu_pct_abundance() function of biom_calc.py.
 
-        :return: Returns OK, if testing goal was achieved, otherwise raises
-                error.
+        :return: Returns OK, if testing goal was achieved, otherwise raises error.
         """
         self.rel_a = bc.relative_abundance(self.biomf)
         self.result = bc.mean_otu_pct_abundance(self.rel_a, ["GG_OTU_1", "GG_OTU_2"])
 
-        # Obtaining lists of function calculations and manual hand calculations
-        func_calc = self.result.values()
-
         # list containing hand calculated relative abundance values
-        hand_calc = [(0.192307692 + 0.161290323 + 0.111111111 + 0.181818182 +
-                      0.086956522 + 0.333333333 + 0.071428571 + 0.230769231 +
-                      0 + 0.083333333) / 10,
-                     (0.076923077 + 0.258064516 + 0.222222222 + 0 + 0.260869565 +
-                      0.148148148 + 0.178571429 + 0.192307692 + 0.111111111 + 0.125) / 10]
+        hand_calc = {"GG_OTU_1": 14.52348298, "GG_OTU_2": 15.73217761,
+                     "GG_OTU_3": 26.58131438, "GG_OTU_4": 22.91732137,
+                     "GG_OTU_5": 20.24570366}
 
         # Testing the validity of the calculations of mean_otu_pct_abundance().
-        for hand, res in zip(hand_calc, func_calc):
+        for oid in ["GG_OTU_1", "GG_OTU_2"]:
             self.assertAlmostEqual(
-                hand*100, res,
-                msg="Mean OTU not calculated accurately."
-                )
+                hand_calc[oid], self.result[oid],
+                msg="Mean OTU percent abundance not calculated accurately."
+            )
 
     def test_MRA(self):
         """
-        Testing mean relative abundance calculation, MRA() function
-        of biom_calc.py.
+        Testing mean relative abundance calculation, MRA() function of biom_calc.py.
 
-        :return: Returns OK, if testing goal was achieved, otherwise
-            raises error.
+        :return: Returns OK, if testing goal was achieved, otherwise raises error.
         """
         self.result = bc.MRA(self.biomf)
-        self.mean_otu = bc.mean_otu_pct_abundance(
-            bc.relative_abundance(self.biomf),
-            ["GG_OTU_1", "GG_OTU_2", "GG_OTU_3", "GG_OTU_4", "GG_OTU_5"]
-            )
 
         # Obtaining lists of function calculations and manual hand calculations
-        func_calc = self.result.values()
-        hand_calc = self.mean_otu.values()
+        hand_calc = {"GG_OTU_1": 14.52348298, "GG_OTU_2": 15.73217761,
+                     "GG_OTU_3": 26.58131438, "GG_OTU_4": 22.91732137,
+                     "GG_OTU_5": 20.24570366}
 
         # Testing the validity of the calculations of mean_otu_pct_abundance()
-        for hand, res in zip(hand_calc, func_calc):
+        for oid in hand_calc.keys():
             self.assertAlmostEqual(
-                hand, res,
-                msg="Mean OTU not calculated accurately."
-                )
+                hand_calc[oid], self.result[oid],
+                msg="Mean relative OTU percent abundance (MRA) not calculated accurately."
+            )
 
     def test_raw_abundance(self):
         """
         Testing raw_abundance() function of biom_calc.py.
 
-        :return: Returns OK, if testing goal is achieved, otherwise raises
-                 error.
+        :return: Returns OK, if testing goal is achieved, otherwise raises error.
         """
         self.result = bc.raw_abundance(self.biomf, sample_abd=False)
         self.result1 = bc.raw_abundance(self.biomf)
@@ -123,12 +139,59 @@ class biom_calc_Test(unittest.TestCase):
         self.assertDictEqual(self.result3, hand_calc3,
                              msg="Abundances not calculated for OTUID's")
 
+    def test_relative_abundance(self):
+        """
+        Testing relative abundance() function of biom.calc.py.
+
+        :return: Returns OK, if testing goal is achieved, otherwise raises error.
+        """
+        self.result = bc.relative_abundance(self.biomf)
+
+        # List containing manual calculations
+        hand_calc = {"S1": {"GG_OTU_1": 0.192307692, "GG_OTU_2": 0.076923077,
+                            "GG_OTU_3": 0.192307692, "GG_OTU_4": 0.346153846,
+                            "GG_OTU_5": 0.192307692},
+                     "S10": {"GG_OTU_1": 0.083333333, "GG_OTU_2": 0.125,
+                             "GG_OTU_3": 0.166666667, "GG_OTU_4": 0.333333333,
+                             "GG_OTU_5": 0.291666667},
+                     "S2": {"GG_OTU_1": 0.161290323, "GG_OTU_2": 0.258064516,
+                            "GG_OTU_3": 0.258064516, "GG_OTU_4": 0.258064516,
+                            "GG_OTU_5": 0.064516129},
+                     "S3": {"GG_OTU_1": 0.111111111, "GG_OTU_2": 0.222222222,
+                            "GG_OTU_3": 0.0, "GG_OTU_4": 0.277777778,
+                            "GG_OTU_5": 0.388888889},
+                     "S4": {"GG_OTU_1": 0.181818182, "GG_OTU_2": 0.0,
+                            "GG_OTU_3": 0.545454545, "GG_OTU_4": 0.272727273,
+                            "GG_OTU_5": 0.0},
+                     "S5": {"GG_OTU_1": 0.086956522, "GG_OTU_2": 0.260869565,
+                            "GG_OTU_3": 0.304347826, "GG_OTU_4": 0.217391304,
+                            "GG_OTU_5": 0.130434783},
+                     "S6": {"GG_OTU_1": 0.333333333, "GG_OTU_2": 0.148148148,
+                            "GG_OTU_3": 0.296296296, "GG_OTU_4": 0.185185185,
+                            "GG_OTU_5": 0.037037037},
+                     "S7": {"GG_OTU_1": 0.071428571, "GG_OTU_2": 0.178571429,
+                            "GG_OTU_3": 0.142857143, "GG_OTU_4": 0.285714286,
+                            "GG_OTU_5": 0.321428571},
+                     "S8": {"GG_OTU_1": 0.230769231, "GG_OTU_2": 0.192307692,
+                            "GG_OTU_3": 0.307692308, "GG_OTU_4": 0.115384615,
+                            "GG_OTU_5": 0.153846154},
+                     "S9": {"GG_OTU_1": 0.0, "GG_OTU_2": 0.111111111,
+                            "GG_OTU_3": 0.444444444, "GG_OTU_4": 0.0,
+                            "GG_OTU_5": 0.444444444}}
+
+        # Testing the validity of relative_abundance() function.
+        for sid in sorted(hand_calc.keys()):
+            for otuid in sorted(hand_calc[sid].keys()):
+                self.assertAlmostEqual(
+                    hand_calc[sid][otuid], self.result[sid][otuid],
+                    msg="Relative abundances not calculated accurately."
+                )
+
     def test_transform_raw_abundance(self):
         """
         Testing transform_raw_abundance() function of biom_calc.py.
 
-        :return: Returns OK if testing goal is achieved, otherwise raises
-                 error.
+        :return: Returns OK if testing goal is achieved, otherwise raises error.
         """
         self.result = bc.transform_raw_abundance(self.biomf, sample_abd=False)
         self.result1 = bc.transform_raw_abundance(self.biomf, fn=math.sqrt)
@@ -137,41 +200,20 @@ class biom_calc_Test(unittest.TestCase):
         hand_calc = {"GG_OTU_1": 1.544068044, "GG_OTU_2": 1.579783597,
                      "GG_OTU_3": 1.73239376, "GG_OTU_4": 1.73239376,
                      "GG_OTU_5": 1.62324929}
-        hand_calc1 = {"S9": 3.0, "S8": 5.09901951, "S3": 4.24264069, "S2": 5.56776436,
-                      "S1": 5.09901951, "S10": 4.89897949, "S7": 5.29150262,
-                      "S6": 5.19615242, "S5": 4.79583152, "S4": 3.31662479}
+        hand_calc1 = {"S1": 5.099019514, "S2": 5.567764363, "S3": 4.242640687,
+                      "S4": 3.31662479, "S5": 4.795831523, "S6": 5.196152423,
+                      "S7": 5.291502622, "S8": 5.099019514, "S9": 3, "S10": 4.898979486}
 
         # Testing the validity of transform function
-        for hand, func in zip(hand_calc.values(), self.result.values()):
+        for oid in hand_calc.keys():
             self.assertAlmostEqual(
-                func, hand,
-                msg="Raw abundance transformation not computed accurately."
+                hand_calc[oid], self.result[oid],
+                msg="Raw abundance transformation not computed accurately (Test1)."
             )
-        for hand1, func1 in zip(hand_calc1.values(), self.result1.values()):
+        for sid in hand_calc1.keys():
             self.assertAlmostEqual(
-                func1, hand1,
-                msg="Raw abundance transformation not computed accurately."
-            )
-
-    def test_arcsine_sqrt_transform(self):
-        """
-        Testing arcsine_sqrt_transform() function of biom_calc.py.
-
-        :return: Returns OK if testing goal is achieved, otherwise raises
-                 error.
-        """
-        self.result1 = bc.relative_abundance(self.biomf)
-        self.result2 = bc.arcsine_sqrt_transform(self.result1)
-
-        # Obtaining results to compare.
-        hand_calc = [0.440510663, 0, 0.830915552, 0.549467245, 0]
-        func_calc = self.result2["S4"].values()
-
-        # Testing validity of the transforms.
-        for hand, func in zip(hand_calc, func_calc):
-            self.assertAlmostEqual(
-                hand, func, places=7,
-                msg="Function did not calculate transformation accurately."
+                hand_calc1[sid], self.result1[sid],
+                msg="Raw abundance transformation not computed accurately (Test2)."
             )
 
     def tearDown(self):

--- a/phylotoast/test/test_otu_calc.py
+++ b/phylotoast/test/test_otu_calc.py
@@ -41,7 +41,7 @@ class otu_calc_Test(unittest.TestCase):
              "f__", "g__Fusobacterium", "s__nucleatum"],
             "Fusobacterium_spp.":
             ["k__Bacteria", "p__Fusobacteria", "c__Fusobacteria", "o__",
-            "f__", "g__Fusobacterium", "s__"]
+             "f__", "g__Fusobacterium", "s__"]
         }
 
         for expected, test in self.taxa.items():

--- a/phylotoast/test/test_util.py
+++ b/phylotoast/test/test_util.py
@@ -1,8 +1,6 @@
 """
 :Author: Akshay Paropkari
-
 :Date Created: 10/13/2014
-
 :Abstract: Automated tests for util.py functions.
 """
 import os
@@ -176,41 +174,35 @@ class util_Test(unittest.TestCase):
                     ut.split_phylogeny(p1, "k"), "k__Bacteria",
                     msg="Error. Identification failed at level 'k'."
                     )
-
             if lvl == "p":
                 self.assertEqual(
                     ut.split_phylogeny(p1, "p"), "k__Bacteria; p__Firmicutes",
                     msg="Error. Identification failed at level 'p'."
                     )
-
             if lvl == "c":
                 self.assertEqual(
                     ut.split_phylogeny(p1, "c"),
                     "k__Bacteria; p__Firmicutes; c__Clostridia",
                     msg="Error. Identification failed at level 'c'."
                     )
-
             if lvl == "o":
                 self.assertEqual(
                     ut.split_phylogeny(p1, "o"),
                     "k__Bacteria; p__Firmicutes; c__Clostridia; o__Clostridiales",
                     msg="Error. Identification failed at level 'o'."
                     )
-
             if lvl == "f":
                 self.assertEqual(
                     ut.split_phylogeny(p1, "f"),
                     "k__Bacteria; p__Firmicutes; c__Clostridia; o__Clostridiales; f__Veillonellaceae",
                     msg="Error. Identification failed at level 'f'."
                     )
-
             if lvl == "g":
                 self.assertEqual(
                     ut.split_phylogeny(p1, "g"),
                     "k__Bacteria; p__Firmicutes; c__Clostridia; o__Clostridiales; f__Veillonellaceae; g__Veillonella",
                     msg="Error. Identification failed at level 'g'."
                     )
-
             if lvl == "s":
                 self.assertEqual(
                     ut.split_phylogeny(p1, "s"),
@@ -276,6 +268,8 @@ class util_Test(unittest.TestCase):
         result8 = ut.gather_categories(self.map_data, self.map_header,
                                        ["Smoking=Never_Smoker", "Treatment",
                                         "Gender=Female"])  # more than 2 categories - mix
+        result9 = ut.gather_categories(self.map_data, self.map_header,
+                                       categories="Nationality:Peru")
 
         # Testing if the function calculates without any categories.
         manual = {"default": DataCategory({"PC.354", "PC.355", "PC.356", "PC.481",
@@ -356,6 +350,16 @@ class util_Test(unittest.TestCase):
             result8, manual8,
             msg="With two or more conditions/categories given, gather_categories() did "
                 "not return SampleIDs for all condition combinations, as expected."
+        )
+
+        # Testing invalid categories or conditions identified
+        manual9 = {"default": DataCategory({"PC.354", "PC.355", "PC.356", "PC.481",
+                                            "PC.593", "PC.607", "PC.634", "PC.635",
+                                            "PC.636"}, {})}
+        self.assertDictEqual(
+            result9, manual9,
+            msg="With invalid category or condition given, gather_categories() did not "
+                "return all SampleIDs as expected."
         )
 
     def test_parse_unifrac(self):

--- a/phylotoast/util.py
+++ b/phylotoast/util.py
@@ -1,7 +1,6 @@
 """
-Created on Feb 2, 2013
-
-:author: Shareef Dabdoub
+:Date: Created on Feb 2, 2013
+:Author: Shareef Dabdoub
 """
 import errno
 import itertools
@@ -197,12 +196,12 @@ def ensure_dir(d):
             # should not happen with os.makedirs
             # ENOENT: No such file or directory
             if os.errno == errno.ENOENT:
-                msg = twdd("""One or more directories in the path ({}) do not exist. If 
-                           you are specifying a new directory for output, please ensure 
+                msg = twdd("""One or more directories in the path ({}) do not exist. If
+                           you are specifying a new directory for output, please ensure
                            all other directories in the path currently exist.""")
                 return msg.format(d)
             else:
-                msg = twdd("""An error occurred trying to create the output directory 
+                msg = twdd("""An error occurred trying to create the output directory
                            ({}) with message: {}""")
                 return msg.format(d, oe.strerror)
 
@@ -262,7 +261,7 @@ def gather_categories(imap, header, categories=None):
 
     cat_ids = [header.index(cat)
                for cat in categories if cat in header and "=" not in cat]
-    
+
     table = OrderedDict()
     conditions = defaultdict(set)
     for i, cat in enumerate(categories):
@@ -270,7 +269,7 @@ def gather_categories(imap, header, categories=None):
             cat_name = header[header.index(cat.split("=")[0])]
             conditions[cat_name].add(cat.split("=")[1])
 
-    # If no categories or conditions identified, return all SampleIDs
+    # If invalid categories or conditions identified, return all SampleIDs
     if not cat_ids and not conditions:
         return {"default": DataCategory(set(imap.keys()), {})}
 
@@ -292,7 +291,7 @@ def gather_categories(imap, header, categories=None):
             continue
     idx_to_test = set(cat_ids).union(cond_ids)
 
-    # If column name and condition given, return overlapping SampleIDs of column and 
+    # If column name and condition given, return overlapping SampleIDs of column and
     # condition combinations
     for sid, row in imap.items():
         if all([row[header.index(c)] in conditions[c] for c in conditions]):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Improved functionality to align closely with PhyloToAST modules. Also, updated syntax for Python 2 and 3 compatibility. No documentation updates needed for these change.
## Description

<!--- Describe your changes in detail -->
- Updated extract_shared_or_unique_otuids.py: 
  - Moved `assign_otu_membership` function to otu_calc module and is now called via otu_calc import.
  - Output parameter `--output_dir` is changed to positional type from optional.
  - Syntax is Python 2 and 3 compatible.
- Updated filter_biom.py: 
  - Switched to using PhyloToAST mapping file reading function from util module.
  - Updated syntax for `biom.filter` function.
  - Removed unused pandas import.
  - Syntax is Python 2 and 3 compatible.
- Updated API and its test script
  - Updated biom_calc to be compatible with Python 2 and 3.
  - Similar changes for test_biom_calc script.
  - Added missed test.
  - Other minor updates. 
- Updated .gitignore:
  - Ignore coverage and other unit testing dot files.
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->
#50
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

Local flake8 on Py2 and Py3 env for syntax and unit testing modules on Py2 env.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
