### PR TITLE
Dimensionality Reduction Updates

### DIFF
--- a/bin/LDA.py
+++ b/bin/LDA.py
@@ -6,7 +6,7 @@ Abstract: This script calculates and returns LDA plots based on normalized relat
 
 import sys
 import argparse
-import warnings
+# import warnings
 from itertools import cycle
 from phylotoast import util, biom_calc as bc, graph_util as gu
 errors = []
@@ -54,8 +54,8 @@ def plot_LDA(X_lda, y_lda, class_colors, exp_var, style, fig_size, label_pad,
         try:
             assert X_lda.shape[1] >= 3
         except AssertionError:
-            sys.exit("\nLinear Discriminant Analysis requires atleast 4 groups of samples "
-                     "to create a 3D figure. Please update group information or use the "
+            sys.exit("\nLinear Discriminant Analysis requires atleast 4 groups of samples"
+                     " to create a 3D figure. Please update group information or use the "
                      "default 2D view of the results.\n")
         if sids is not None:
             print("\nPoint annotations are available only for 2D figure.\n")
@@ -92,8 +92,7 @@ def plot_LDA(X_lda, y_lda, class_colors, exp_var, style, fig_size, label_pad,
                     point = (point[0], cats.index(group)+1)
                 finally:
                     ax.annotate(s=sample, xy=point[:2], xytext=(0, -15), ha="center",
-                                 va="center", textcoords="offset points")
-
+                                va="center", textcoords="offset points")
     if X_lda.shape[1] == 1:
         plt.ylim((0.5, 2.5))
     try:
@@ -134,13 +133,13 @@ def run_LDA(df):
 
     # Calculate LDA
     sklearn_lda = LDA()
-    try:
-        X_lda_sklearn = sklearn_lda.fit_transform(X, y)
-    except Exception as e:
-        print("\nWarning: {}\nPlease reduce your feature (OTU/gene) list by removing "
-              "highly correlated features using Variance Inflation Factor. Another "
-              "approach maybe to perform PCoA, instead of LDA.".format(e))
-        continue
+#     try:
+    X_lda_sklearn = sklearn_lda.fit_transform(X, y)
+#     except Exception as e:
+#         pass
+#         print("\nWarning: {} Please reduce your feature (OTU/gene) list by removing "
+#               "highly correlated features using Variance Inflation Factor. Another "
+#               "approach maybe to perform PCoA, instead of LDA.".format(e))
     try:
         exp_var = sklearn_lda.explained_variance_ratio_
     except AttributeError as ae:
@@ -199,8 +198,8 @@ def handle_program_options():
 
 
 def main():
-    warnings.filterwarnings("error")
     args = handle_program_options()
+#     warnings.filterwarnings("error")
 
     # Parse and read mapping file
     try:
@@ -222,12 +221,10 @@ def main():
 
     if args.dist_matrix_file:
         try:
-            with open(args.dist_matrix_file):
-                pass
+            uf_data = pd.read_csv(args.dist_matrix_file, sep="\t", index_col=0)
         except IOError as ioe:
             err_msg = "\nError with unifrac distance matrix file (-d): {}\n"
             sys.exit(err_msg.format(ioe))
-        uf_data = pd.read_csv(args.dist_matrix_file, sep="\t", index_col=0)
         uf_data.insert(0, "Condition", [imap[sid][category_idx] for sid in uf_data.index])
         if args.annotate_points:
             sampleids = uf_data.index

--- a/bin/LDA.py
+++ b/bin/LDA.py
@@ -53,11 +53,11 @@ def plot_LDA(X_lda, y_lda, class_colors, exp_var, style, fig_size, label_pad,
         try:
             assert X_lda.shape[1] >= 3
         except AssertionError:
-            sys.exit("\nLinear Discriminant Analysis requires atleast 4 groups of samples"
-                     " to create a 3D figure. Please update group information or use the "
-                     "default 2D view of the results.\n")
+            sys.exit("\nLinear Discriminant Analysis requires at least 4 groups of "
+                     "samples to create a 3D figure. Please update group information or "
+                     "use the default 2D view of the results.\n")
         if sids is not None:
-            print("\nPoint annotations are available only for 2D figure.\n")
+            print("\nPoint annotations are available only for 2D figures.\n")
         ax = fig.add_subplot(111, projection="3d")
         ax.view_init(elev=zangles[1], azim=zangles[0])
         try:
@@ -158,7 +158,7 @@ def handle_program_options():
                         help="A column name in the mapping file containing hexadecimal "
                              "(#FF0000) color values that will be used to color the "
                              "groups. Each sample ID must have a color entry.")
-    parser.add_argument("-i", "--otu_table", help="Input biom file format OTU table.")
+    parser.add_argument("-ot", "--otu_table", help="Input biom file format OTU table.")
     parser.add_argument("-dm", "--dist_matrix_file", help="Input distance matrix file.")
     parser.add_argument("--save_lda_input",
                         help="Save a CSV-format file of the transposed LDA-input table to"
@@ -213,19 +213,19 @@ def main():
 
     if args.dist_matrix_file:
         try:
-            uf_data = pd.read_csv(args.dist_matrix_file, sep="\t", index_col=0)
+            dm_data = pd.read_csv(args.dist_matrix_file, sep="\t", index_col=0)
         except IOError as ioe:
             err_msg = "\nError with unifrac distance matrix file (-d): {}\n"
             sys.exit(err_msg.format(ioe))
-        uf_data.insert(0, "Condition", [imap[sid][category_idx] for sid in uf_data.index])
+        dm_data.insert(0, "Condition", [imap[sid][category_idx] for sid in dm_data.index])
         if args.annotate_points:
-            sampleids = uf_data.index
+            sampleids = dm_data.index
         else:
             sampleids = None
         if args.save_lda_input:
-            uf_data.to_csv(args.save_lda_input, sep="\t")
+            dm_data.to_csv(args.save_lda_input, sep="\t")
         # Run LDA
-        X_lda, y_lda, exp_var = run_LDA(uf_data)
+        X_lda, y_lda, exp_var = run_LDA(dm_data)
     else:
         # Load biom file and calculate relative abundance
         try:

--- a/bin/LDA.py
+++ b/bin/LDA.py
@@ -6,7 +6,6 @@ Abstract: This script calculates and returns LDA plots based on normalized relat
 
 import sys
 import argparse
-# import warnings
 from itertools import cycle
 from phylotoast import util, biom_calc as bc, graph_util as gu
 errors = []
@@ -133,13 +132,7 @@ def run_LDA(df):
 
     # Calculate LDA
     sklearn_lda = LDA()
-#     try:
     X_lda_sklearn = sklearn_lda.fit_transform(X, y)
-#     except Exception as e:
-#         pass
-#         print("\nWarning: {} Please reduce your feature (OTU/gene) list by removing "
-#               "highly correlated features using Variance Inflation Factor. Another "
-#               "approach maybe to perform PCoA, instead of LDA.".format(e))
     try:
         exp_var = sklearn_lda.explained_variance_ratio_
     except AttributeError as ae:
@@ -199,7 +192,6 @@ def handle_program_options():
 
 def main():
     args = handle_program_options()
-#     warnings.filterwarnings("error")
 
     # Parse and read mapping file
     try:

--- a/bin/LDA.py
+++ b/bin/LDA.py
@@ -6,6 +6,7 @@ Abstract: This script calculates and returns LDA plots based on normalized relat
 
 import sys
 import argparse
+import warnings
 from itertools import cycle
 from phylotoast import util, biom_calc as bc, graph_util as gu
 errors = []
@@ -133,7 +134,13 @@ def run_LDA(df):
 
     # Calculate LDA
     sklearn_lda = LDA()
-    X_lda_sklearn = sklearn_lda.fit_transform(X, y)
+    try:
+        X_lda_sklearn = sklearn_lda.fit_transform(X, y)
+    except Exception as e:
+        print("\nWarning: {}\nPlease reduce your feature (OTU/gene) list by removing "
+              "highly correlated features using Variance Inflation Factor. Another "
+              "approach maybe to perform PCoA, instead of LDA.".format(e))
+        continue
     try:
         exp_var = sklearn_lda.explained_variance_ratio_
     except AttributeError as ae:
@@ -192,6 +199,7 @@ def handle_program_options():
 
 
 def main():
+    warnings.filterwarnings("error")
     args = handle_program_options()
 
     # Parse and read mapping file

--- a/bin/PCoA.py
+++ b/bin/PCoA.py
@@ -22,77 +22,70 @@ if len(errors) != 0:
 
 
 def handle_program_options():
-    parser = argparse.ArgumentParser(description="Create a 2D or 3D PCoA plot. "
-                                     "By default, this script opens a window "
-                                     "with the plot displayed if you want to "
-                                     "change certain aspects of the plot (such "
-                                     "as rotate the view in 3D mode). If the -o "
-                                     "option is specified, the plot will be "
-                                     "saved directly to an image without "
-                                     "the initial display window.")
+    parser = argparse.ArgumentParser(description="Create a 2D or 3D PCoA plot. By default"
+                                     ", this script opens a window with the plot "
+                                     "displayed if you want to change certain aspects of "
+                                     "the plot (such as rotate the view in 3D mode). If "
+                                     "the -o option is specified, the plot will be saved "
+                                     "directly to an image without the initial display "
+                                     "window.")
     parser.add_argument("-i", "--coord_fp", required=True,
-                        help="Input principal coordinates filepath (i.e., "
-                             "resulting file from principal_coordinates.py) "
-                             "[REQUIRED].")
+                        help="Input principal coordinates filepath (i.e. resulting file "
+                             "from principal_coordinates.py) [REQUIRED].")
     parser.add_argument("-m", "--map_fp", required=True,
                         help="Input metadata mapping filepath [REQUIRED].")
     parser.add_argument("-g", "--group_by", required=True,
-                        help="Any mapping categories, such as treatment type,  "
-                              "that will be used to group the data in the  "
-                              "output iTol table. For example, one category  "
-                              "with three types will result in three data  "
-                              "columns in the final output. Two categories with "
-                              "three types each will result in six data  "
-                              "columns. Default is no categories and all the  "
-                              "data will be treated as a single group.")
-    parser.add_argument("-d", "--dimensions", default=2, type=int,
-                        choices=[2, 3],
+                        help="Any mapping categories, such as treatment type, that will "
+                        "be used to group the data in the output iTol table. For example,"
+                        " one category with three types will result in three data columns"
+                        " in the final output. Two categories with three types each will "
+                        "result in six data columns. Default is no categories and all the"
+                        " data will be treated as a single group.")
+    parser.add_argument("-d", "--dimensions", default=2, type=int, choices=[2, 3],
                         help="Choose whether to plot 2D or 3D.")
     parser.add_argument("-c", "--colors", default=None,
-                        help="A column name in the mapping file containing "
-                              "hexadecimal (#FF0000) color values that will "
-                              "be used to color the groups. Each sample ID must "
-                              "have a color entry.")
+                        help="A column name in the mapping file containing hexadecimal "
+                        "(#FF0000) color values that will be used to color the groups. "
+                        "Each sample ID must have a color entry.")
     parser.add_argument("-s", "--point_size", default=100, type=int,
-                        help="Specify the size of the circles representing each "
-                             "of the samples in the plot")
+                        help="Specify the size of the circles representing each of the "
+                        "samples in the plot")
     parser.add_argument("--pc_order", default=[1, 2], type=int, nargs=2,
-                        help="Choose which Principle Coordinates are displayed "
-                        "and in which order, for example: 1 2. This option "
-                        "is only used when a 2D plot is specified.")
+                        help="Choose which Principle Coordinates are displayed and in "
+                        "which order, for example: 1 2. This option is only used when a "
+                        "2D plot is specified.")
     parser.add_argument("--x_limits", type=float, nargs=2,
-                        help="Specify limits for the x-axis instead of "
-                             "automatic setting based on the data range. Should "
-                             "take the form: --x_limits -0.5 0.5")
+                        help="Specify limits for the x-axis instead of automatic setting "
+                        "based on the data range. Should take the form: --x_limits -0.5 "
+                        "0.5")
     parser.add_argument("--y_limits", type=float, nargs=2,
-                        help="Specify limits for the y-axis instead of "
-                             "automatic setting based on the data range. Should "
-                             "take the form: --y_limits -0.5 0.5")
+                        help="Specify limits for the y-axis instead of automatic setting "
+                        "based on the data range. Should take the form: --y_limits -0.5 "
+                        "0.5")
     parser.add_argument("--z_limits", type=float, nargs=2,
-                        help="Specify limits for the z-axis instead of "
-                             "automatic setting based on the data range. Should "
-                             "take the form: --z_limits -0.5 0.5")
+                        help="Specify limits for the z-axis instead of automatic setting "
+                        "based on the data range. Should take the form: --z_limits -0.5 "
+                        "0.5")
     parser.add_argument("--z_angles", type=float, nargs=2, default=[-134.5, 23.],
                         help="Specify the azimuth and elevation angles for a 3D plot.")
     parser.add_argument("-t", "--title", default="", help="Title of the plot.")
     parser.add_argument("--figsize", default=[14, 8], type=int, nargs=2,
-                        help="Specify the 'width height' in inches for PCoA plots."
-                             "By default, figure size is 14x8 inches")
+                        help="Specify the 'width height' in inches for PCoA plots. "
+                        "Default figure size is 14x8 inches")
     parser.add_argument("--font_size", default=12, type=int,
                         help="Sets the font size for text elements in the plot.")
     parser.add_argument("--label_padding", default=15, type=int,
-                        help="Sets the spacing in points between the each axis and "
-                        "its label.")
+                        help="Sets the spacing in points between the each axis and its "
+                        "label.")
     parser.add_argument("--annotate_points", action="store_true",
-                        help="If specified, each graphed point will be labeled with "
-                        "its sample ID.")
+                        help="If specified, each graphed point will be labeled with its "
+                        "sample ID.")
     parser.add_argument("--ggplot2_style", action="store_true",
                         help="Apply ggplot2 styling to the figure.")
     parser.add_argument("-o", "--out_fp", default=None,
-                        help="The path and file name to save the plot under. "
-                              "If specified, the figure will be saved directly "
-                              "instead of opening a window in which the plot can "
-                              "be viewed before saving.")
+                        help="The path and file name to save the plot under. If specified"
+                        ", the figure will be saved directly instead of opening a window "
+                        "in which the plot can be viewed before saving.")
     return parser.parse_args()
 
 
@@ -172,12 +165,12 @@ def main():
             ax.scatter(xs=[e[1] for e in categories[cat]["pc1"]],
                        ys=[e[1] for e in categories[cat]["pc2"]],
                        zs=[e[1] for e in categories[cat]["pc3"]],
-                       zdir="z", c=colors[i], s=args.point_size,
-                       label=cat)
+                       zdir="z", c=colors[i], s=args.point_size, label=cat,
+                       edgecolors="k")
         else:
             ax.scatter([e[1] for e in categories[cat]["pc1"]],
                        [e[1] for e in categories[cat]["pc2"]],
-                       c=colors[i], s=args.point_size, label=cat)
+                       c=colors[i], s=args.point_size, label=cat, edgecolors="k")
 
         # Script to annotate PCoA sample points.
         if args.annotate_points:

--- a/docs/scripts/LDA.txt
+++ b/docs/scripts/LDA.txt
@@ -6,14 +6,10 @@ This script calculates and returns LDA plots based on normalized relative abunda
 
 .. code-block:: bash
 
-        usage: LDA.py [-h] -i OTU_TABLE -m MAP_FP -g GROUP_BY -c COLOR_BY [-dm DIST_MATRIX_FILE] [--save_lda_input SAVE_LDA_INPUT] [--plot_title PLOT_TITLE] [-o OUT_FP] [-d {2,3}] [--z_angles Z_ANGLES Z_ANGLES] [--figsize FIGSIZE FIGSIZE] [--font_size FONT_SIZE] [--label_padding LABEL_PADDING] [--ggplot2_style]
+        usage: LDA.py [-h] -m MAP_FP -g GROUP_BY [-c COLORS] [-i OTU_TABLE] [-dm DIST_MATRIX_FILE] [--save_lda_input SAVE_LDA_INPUT] [--plot_title PLOT_TITLE] [-o OUT_FP] [-d {2,3}] [--z_angles Z_ANGLES Z_ANGLES] [--figsize FIGSIZE FIGSIZE] [--font_size FONT_SIZE] [--label_padding LABEL_PADDING] [--annotate_points] [--ggplot2_style]
 
 Required arguments
 ^^^^^^^^^^^^^^^^^^^^
-
-.. cmdoption:: -i OTU_TABLE, --otu_table OTU_TABLE
-
-    Input biom file format OTU table.
 
 .. cmdoption:: -m MAP_FP, --map_fp MAP_FP
 
@@ -29,6 +25,10 @@ Optional arguments
 .. cmdoption:: -c COLORS, --colors COLORS
 
     A column name in the mapping file containing hexadecimal (#FF0000) color values that will be used to color the groups. Each sample ID must have a color entry.
+
+.. cmdoption:: -i OTU_TABLE, --otu_table OTU_TABLE
+
+    Input biom file format OTU table.
 
 .. cmdoption:: -dm DIST_MATRIX_FILE, --dist_matrix_file DIST_MATRIX_FILE
 
@@ -83,7 +83,7 @@ Workflow for generating LDA plots using PhyloToAST
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Step 1** :
-Create an all-pairs distance matrix for your sample data using the `beta_diversity.py <http://qiime.org/scripts/beta_diversity.html>`_ QIIME script. Different distance metrics can be calculated here: bray_cutis, morisita_horn, kulczynski, and many others.
+Create an all-pairs distance matrix for your sample data using the `beta_diversity.py <http://qiime.org/scripts/beta_diversity.html>`_ QIIME script. Different distance metrics can be calculated here: bray_curtis, morisita_horn, kulczynski, and many others.
 
 **Step 2** :
 Users can use either diversity distance matrix file or BIOM format file to run ``LDA.py`` script with all relevant parameters. If a distance matrix file is provided, LDA will use the distance matrix as an input, otherwise it will calculate OTU relative abundances from input BIOM format file and run LDA based on OTU relative abundances.

--- a/docs/scripts/LDA.txt
+++ b/docs/scripts/LDA.txt
@@ -6,7 +6,7 @@ This script calculates and returns LDA plots based on normalized relative abunda
 
 .. code-block:: bash
 
-        usage: LDA.py [-h] -m MAP_FP -g GROUP_BY [-c COLORS] [-i OTU_TABLE] [-dm DIST_MATRIX_FILE] [--save_lda_input SAVE_LDA_INPUT] [--plot_title PLOT_TITLE] [-o OUT_FP] [-d {2,3}] [--z_angles Z_ANGLES Z_ANGLES] [--figsize FIGSIZE FIGSIZE] [--font_size FONT_SIZE] [--label_padding LABEL_PADDING] [--annotate_points] [--ggplot2_style]
+        usage: LDA.py [-h] -m MAP_FP -g GROUP_BY [-c COLORS] [-ot OTU_TABLE] [-dm DIST_MATRIX_FILE] [--save_lda_input SAVE_LDA_INPUT] [--plot_title PLOT_TITLE] [-o OUT_FP] [-d {2,3}] [--z_angles Z_ANGLES Z_ANGLES] [--figsize FIGSIZE FIGSIZE] [--font_size FONT_SIZE] [--label_padding LABEL_PADDING] [--annotate_points] [--ggplot2_style]
 
 Required arguments
 ^^^^^^^^^^^^^^^^^^^^
@@ -26,7 +26,7 @@ Optional arguments
 
     A column name in the mapping file containing hexadecimal (#FF0000) color values that will be used to color the groups. Each sample ID must have a color entry.
 
-.. cmdoption:: -i OTU_TABLE, --otu_table OTU_TABLE
+.. cmdoption:: -ot OTU_TABLE, --otu_table OTU_TABLE
 
     Input biom file format OTU table.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- In LDA:
  - Added checks for invalid use of 3D figures.
  - Removed sample annotation for 3D figures, now it is only available for 2D images.
  - Annotations now support 1D figures as well.
  - Parameter `—otu_table` is now optional.
  - Updated Pandas method to extract input values for calculations from dataframe.
  - Updated documentation.

- In PCoA:
  - Added edge colors to scatter plots.

- All figures were tested on matplotlib version 2.0.2.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Compatibility with matplotlib >=v2.0
- Better checks for discriminant analysis, providing users useful feedback for ease of use.
- #47 - User-friendly 3D LDA visualization process

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- All tests using command `python -m unittest discover -s phylotoast/test/ -vf` ran successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read  he **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
